### PR TITLE
add spyOnProperty snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Below is a list of all available snippets and the triggers of each one. The **�
 |`so→`     | spyOn |
 |`sct→`    | spyOn.and.callThrough |
 |`scf→`    | spyOn.and.callFake |
+|`spg→`     | spyOnProperty($obj,'$property', 'get') |
+|`sps→`     | spyOnProperty($obj,'$property', 'set') |
 |`srv→`    | spyOn.and.returnValue |
 |`ss→`     | spyOn.and.stub |
 |`ste→`    | spyOn.and.throwError |

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -221,6 +221,18 @@
 		"description": "all calls to the spy will throw the specified value as an error",
 		"scope": "source.js"
 	},
+	"spyOnProperty get": {
+		"prefix": "spg",
+		"body": "spyOnProperty(${1:object}, '${2:method}', 'get')$3;$0",
+		"description": "Install a spy on a property onto an existing object with get accessType",
+		"scope": "source.js"
+	},
+	"spyOnProperty set": {
+		"prefix": "sps",
+		"body": "spyOnProperty(${1:object}, '${2:method}', 'set')$3;$0",
+		"description": "Install a spy on a property onto an existing object with set accessType",
+		"scope": "source.js"
+	},
 	"spyOn": {
 		"prefix": "so",
 		"body": "spyOn(${1:object}, '${2:method}')$3;$0\n\t",


### PR DESCRIPTION
I add 2 new snippets for [spyOnProperty()](https://jasmine.github.io/api/2.6/global.html#spyOnProperty) method.

Hope that looks good.

PS: I made sure it didn't have any newlines.

