### PR TITLE
Lexical this and cleanup

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -43,7 +43,7 @@
 	},
 	"callsArgsFor": {
 		"prefix": "caf",
-		"body": "${1:spy}.calls.argsFor(${2:call number})",
+		"body": "${1:spy}.calls.argsFor(${2:i})",
 		"description": "returns the arguments passed to call number index",
 		"scope": "source.js"
 	},

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -121,7 +121,7 @@
 	},
 	"objectContaining": {
 		"prefix": "oc",
-		"body": "jasmine.objectContaining('${1:key}': ${2:value}\\}})$0",
+		"body": "jasmine.objectContaining({'${1:key}': ${2:value}})$0",
 		"description": "when an expectation only cares about certain key/value pairs in the actual",
 		"scope": "source.js"
 	},

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1,8 +1,20 @@
 {
+	"afterAll": {
+		"prefix": "aa",
+		"body": "afterAll(function() {\n\t$1\n});",
+		"description": "afterAll function is called once after all specs",
+		"scope": "source.js"
+	},
 	"afterEach": {
 		"prefix": "ae",
 		"body": "afterEach(function() {\n\t$1\n});",
 		"description": "afterEach function is called once after each spec",
+		"scope": "source.js"
+	},
+	"beforeAll": {
+		"prefix": "ba",
+		"body": "beforeAll(function() {\n\t$1\n});",
+		"description": "beforeAll function is called once before any specs",
 		"scope": "source.js"
 	},
 	"beforeEach": {

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1,13 +1,13 @@
 {
 	"afterEach": {
 		"prefix": "ae",
-		"body": "afterEach(() => {\n\t$1\n});",
+		"body": "afterEach(function() {\n\t$1\n});",
 		"description": "afterEach function is called once after each spec",
 		"scope": "source.js"
 	},
 	"beforeEach": {
 		"prefix": "be",
-		"body": "beforeEach(() => {\n\t$1\n});",
+		"body": "beforeEach(function() {\n\t$1\n});",
 		"description": "beforeEach function is called once before each spec",
 		"scope": "source.js"
 	},
@@ -91,13 +91,13 @@
 	},
 	"focusedIt": {
 		"prefix": "fit",
-		"body": "fit('${1:should behave...}', () => {\n    $2\n});\n    ",
+		"body": "fit('${1:should behave...}', function() {\n    $2\n});\n    ",
 		"description": "focused it",
 		"scope": "source.js"
 	},
 	"it": {
 		"prefix": "it",
-		"body": "it('${1:should behave...}', () => {\n\t$2\n});",
+		"body": "it('${1:should behave...}', function() {\n\t$2\n});",
 		"description": "creates a test method",
 		"scope": "source.js"
 	},
@@ -343,7 +343,7 @@
 	},
 	"xIt": {
 		"prefix": "xit",
-		"body": "xit('${1:should behave...}', () => {\n\t$2\n});",
+		"body": "xit('${1:should behave...}', function() {\n\t$2\n});",
 		"description": "pending specs do not run, but their names will show up in the results as pending",
 		"scope": "source.js"
 	}

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -89,7 +89,7 @@
 		"description": "creates a suite of tests",
 		"scope": "source.js"
 	},
-	"expext": {
+	"expect": {
 		"prefix": "exp",
 		"body": "expect($1)$0",
 		"description": "takes a value, called the actual.",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -97,13 +97,13 @@
 	},
 	"focusDescribe": {
 		"prefix": "fdesc",
-		"body": "fdescribe('${1:Name of the group}', () => {\n    $2\n});\n    ",
+		"body": "fdescribe('${1:Name of the group}', () => {\n\t$2\n});",
 		"description": "focused describe",
 		"scope": "source.js"
 	},
 	"focusedIt": {
 		"prefix": "fit",
-		"body": "fit('${1:should behave...}', function() {\n    $2\n});\n    ",
+		"body": "fit('${1:should behave...}', function() {\n\t$2\n});",
 		"description": "focused it",
 		"scope": "source.js"
 	},
@@ -205,7 +205,7 @@
 	},
 	"spyOnAndCallFake": {
 		"prefix": "scf",
-		"body": "spyOn(${1:object}, '${2:method}').and.callFake(${3:() => \\{\n    $4\n\\}});$0\n    ",
+		"body": "spyOn(${1:object}, '${2:method}').and.callFake(${3:() => {\n\t$4\n}});$0",
 		"description": "all calls to the spy will delegate to the supplied function",
 		"scope": "source.js"
 	},


### PR DESCRIPTION
There are a few things in this pull request:

1. Adds `afterAll` and `beforeAll`
2. Updates `it`-, `before`-, and `after`-related functions *not* to use arrow functions by default.
    - Using arrow functions prevents access to the context object Jasmine provides for sharing data amongst tests. This is a commonly-used feature of Jasmine, and it seems wrong that the snippets would by default prevent access to a feature provided by the tool the snippets are for.
3. Normalizes white space. There were a few places where 4 spaces were explicitly being used instead of a tab indicator, leading to unexpected and inconsistent white space handling when using snippets.
4. Fixes `spyOnAndCallFake` to not include an extra `\` intended (but not actually used) as an escape character.
5. Update callsArgsFor to use a common default value for call number that could be used as-is (`i` vs `call number`—if you want to use the default of `i`, you can just tab over that field).
6. Fixes the syntax of `objectContaining` (#11). There is another PR that fixes this as well, but I wanted a single file that has all the fixes we need so an equivalent fix is included here.