### PR TITLE
Modify the package.json to support .jsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
       {
       	"language": "typescriptreact",
         "path": "./snippets/snippets.json"
+      },
+      {
+      	"language": "javascriptreact",
+        "path": "./snippets/snippets.json"
       }
     ]
   }


### PR DESCRIPTION
Great package! I've been using it quite often but am bummed out by lack of `.jsx` support. Some of the unit tests I interact with are written as `.jsx` as opposed to `.js`. 

I'd love to see `.jsx` support added. I've made the changes that I believe will add `.jsx` support to this package. Please let me know if I am missing anything!

