### PR TITLE
Keep final cursor position on the last position

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1,13 +1,13 @@
 {
 	"afterEach": {
 		"prefix": "ae",
-		"body": "afterEach(() => {\n\t$1\n});",
+		"body": "afterEach(() => {\n\t$0\n});",
 		"description": "afterEach function is called once after each spec",
 		"scope": "source.js"
 	},
 	"beforeEach": {
 		"prefix": "be",
-		"body": "beforeEach(() => {\n\t$1\n});",
+		"body": "beforeEach(() => {\n\t$0\n});",
 		"description": "beforeEach function is called once before each spec",
 		"scope": "source.js"
 	},
@@ -73,7 +73,7 @@
 	},
 	"describe": {
 		"prefix": "desc",
-		"body": "describe('${1:Name of the group}', () => {\n\t$2\n});",
+		"body": "describe('${1:Name of the group}', () => {\n\t$0\n});",
 		"description": "creates a suite of tests",
 		"scope": "source.js"
 	},
@@ -85,19 +85,19 @@
 	},
 	"focusDescribe": {
 		"prefix": "fdesc",
-		"body": "fdescribe('${1:Name of the group}', () => {\n    $2\n});\n    ",
+		"body": "fdescribe('${1:Name of the group}', () => {\n    $0\n});\n    ",
 		"description": "focused describe",
 		"scope": "source.js"
 	},
 	"focusedIt": {
 		"prefix": "fit",
-		"body": "fit('${1:should behave...}', () => {\n    $2\n});\n    ",
+		"body": "fit('${1:should behave...}', () => {\n    $0\n});\n    ",
 		"description": "focused it",
 		"scope": "source.js"
 	},
 	"it": {
 		"prefix": "it",
-		"body": "it('${1:should behave...}', () => {\n\t$2\n});",
+		"body": "it('${1:should behave...}', () => {\n\t$0\n});",
 		"description": "creates a test method",
 		"scope": "source.js"
 	},
@@ -337,13 +337,13 @@
 	},
 	"xDescribe": {
 		"prefix": "xdesc",
-		"body": "xdescribe('${1:Name of the group}', () => {\n\t$2\n});",
+		"body": "xdescribe('${1:Name of the group}', () => {\n\t$0\n});",
 		"description": "these suites and any specs inside them are skipped when run and thus their results will not appear in the results",
 		"scope": "source.js"
 	},
 	"xIt": {
 		"prefix": "xit",
-		"body": "xit('${1:should behave...}', () => {\n\t$2\n});",
+		"body": "xit('${1:should behave...}', () => {\n\t$0\n});",
 		"description": "pending specs do not run, but their names will show up in the results as pending",
 		"scope": "source.js"
 	}


### PR DESCRIPTION
In Visual Studio Code Snippet, the `$0` denotes the final cursor position.  So this PR fixes all the snippets to improve user experience.