### PR TITLE
Fixing spy on and call fake

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | `xit→`       | xit method |
 | `fit→`       | fit method |
 | `ae→`        | after each method |
+| `aa→`        | after all methods |
 | `be→`        | before each method |
+| `ba→`        | before all methods |
 
 ### Expectations
 | Trigger  | Content |

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -205,7 +205,7 @@
 	},
 	"spyOnAndCallFake": {
 		"prefix": "scf",
-		"body": "spyOn(${1:object}, '${2:method}').and.callFake(${3:() => \\{\n    $4\n\\}});$0\n    ",
+		"body": "spyOn(${1:object}, '${2:method}').and.callFake(${3:() => {\n    ${4:throw \"notImplemented\"}\n\\}});$0\n",
 		"description": "all calls to the spy will delegate to the supplied function",
 		"scope": "source.js"
 	},

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -5,10 +5,22 @@
 		"description": "afterEach function is called once after each spec",
 		"scope": "source.js"
 	},
+	"afterAll": {
+		"prefix": "aa",
+		"body": "afterAll(() => {\n\t$1\n});",
+		"description": "afterAll function is called once after the full spec runs",
+		"scope": "source.js"
+	},
 	"beforeEach": {
 		"prefix": "be",
 		"body": "beforeEach(() => {\n\t$1\n});",
 		"description": "beforeEach function is called once before each spec",
+		"scope": "source.js"
+	},
+	"beforeAll": {
+		"prefix": "ba",
+		"body": "beforeall(() => {\n\t$1\n});",
+		"description": "beforeAll function is called once before the full spec runs",
 		"scope": "source.js"
 	},
 	"callsAll": {


### PR DESCRIPTION
The snippet had a double back slash (comment) that was escaped, resulting in only one back slash breaking the code. I removed the double back slashes and formatted the content of the anonymous function to throw a NotImplemented at the very least, if the user doesn't change it, returning something valid, the code still builds and results in a failing test.